### PR TITLE
fix(auth): corregir obtención de userId desde ClaimTypes.NameIdentifi…

### DIFF
--- a/skillJas.Api/Controllers/FavoritesController.cs
+++ b/skillJas.Api/Controllers/FavoritesController.cs
@@ -20,7 +20,7 @@ namespace skillJas.Api.Controllers
         [HttpPost]
         public async Task<IActionResult> AddFavorite([FromBody] AddFavoriteDto dto)
         {
-            var userId = User.Claims.FirstOrDefault(c => c.Type == "sub")?.Value;
+            var userId = User.FindFirst(System.Security.Claims.ClaimTypes.NameIdentifier)?.Value;
             if (string.IsNullOrEmpty(userId))
                 return Unauthorized("Invalid user token.");
 
@@ -49,6 +49,5 @@ namespace skillJas.Api.Controllers
             var favorites = await _favoriteService.GetFavoritesAsync(userId);
             return Ok(favorites);
         }
-
     }
 }


### PR DESCRIPTION
…er en FavoritesController

Se actualizó la forma de obtener el userId en FavoritesController, usando ClaimTypes.NameIdentifier en lugar de buscar directamente el claim "sub". Esto asegura compatibilidad con Clerk y evita errores de token inválido aunque el JWT sea correcto.